### PR TITLE
Fix null reference with cachedData for some WP8 devices

### DIFF
--- a/app/scripts/external/kendo.data.localstoragedatasource.js
+++ b/app/scripts/external/kendo.data.localstoragedatasource.js
@@ -90,7 +90,7 @@
         read: function (operation) {
             console.log('reading');
             var cashedData = getFromLocalStorage();
-            if (cashedData.length !== 0) {
+            if (cashedData != null && cashedData != undefined && cashedData.length !== 0)  {
                 console.log("grabbed", cashedData.length);
                 operation.success(cashedData);
             } 


### PR DESCRIPTION
We had some customers complaining for black screen or only menu.json is shown on WP8 devices.

ping @tjvantoll @jlooper @barranger 